### PR TITLE
remove storages from settings.py

### DIFF
--- a/jersey_her/settings.py
+++ b/jersey_her/settings.py
@@ -93,7 +93,6 @@ INSTALLED_APPS = (
     "corsheaders",
     "oauth2_provider",
     "django_celery_results",
-    "storages",
     "jersey_her",
 )
 


### PR DESCRIPTION
Storages removed from settings.py (and added to settings_local.py). 

This seems to work okay for me. No obvious issues and I've verified storages is still there via a print statement in settings_local.

The tests are still failing, but I think it's only the target branch that's failing to build for this reason, so should be okay after the merge. The feature_branch is failing due to checks related to black, so a separate issue. 