### PR TITLE
Fix for SampleIndex class

### DIFF
--- a/jersey_her/search_indexes/sample_index.py
+++ b/jersey_her/search_indexes/sample_index.py
@@ -5,11 +5,9 @@ class SampleIndex(BaseIndex):
     def prepare_index(self):
         self.index_metadata = {
             "mappings": {
-                "_doc": {
-                    "properties": {
-                        "tile_count": {"type": "keyword"},
-                        "graph_id": {"type": "keyword"},
-                    }
+                "properties": {
+                    "tile_count": {"type": "keyword"},
+                    "graph_id": {"type": "keyword"},
                 }
             }
         }


### PR DESCRIPTION
Fixing the sample_index.py file in /search_indexes, by removing the _doc line.  Test now passes. 