### PR TITLE
Fix default.js in v7.6.x

### DIFF
--- a/jersey_her/media/js/reports/default.js
+++ b/jersey_her/media/js/reports/default.js
@@ -1,10 +1,14 @@
-define(['knockout', 'viewmodels/report'], function (ko, ReportViewModel) {
+define([
+    'knockout', 
+    'viewmodels/report', 
+    'templates/views/report-templates/default.htm'
+], function(ko, ReportViewModel, defaultReportTemplate) {
     return ko.components.register('default-report', {
         viewModel: function(params) {
             params.configKeys = [];
 
             ReportViewModel.apply(this, [params]);
         },
-        template: { require: 'text!report-templates/default' }
+        template: defaultReportTemplate
     });
 });


### PR DESCRIPTION
A small change between v6 -> v7.6 causes the report view not show correctly in the resource, or the report to render properly if there isn't a header:

<img width="1570" height="743" alt="image" src="https://github.com/user-attachments/assets/7af4bb45-1f84-40ca-8fd2-c665a3c11e27" />


This fixes this.
