### PR TITLE
Fix for printing a map header in reports

### DIFF
--- a/jersey_her/media/css/jersey-customisations.css
+++ b/jersey_her/media/css/jersey-customisations.css
@@ -15,3 +15,26 @@
 .tick-styling {
     color: green;
 }
+
+@media print {
+    /* note: '.toggle-container' has been removed on dev/7.6.x */
+    .mapboxgl-ctrl-geocoder,
+    .workbench-card-sidebar,
+    .report-print-date  > .toggle-container {
+        display: none;
+    }
+
+    .workbench-card-container.map-container {
+        width: 100%;
+    }
+
+    .mapboxgl-map {
+        display: block;
+    }
+
+    /* Fix multi-page printing bug (fixed on dev/7.6.x) */
+    .resource-component-abstract {
+        height: auto !important;
+        overflow: visible !important;
+    }
+}

--- a/jersey_her/media/css/jersey-customisations.css
+++ b/jersey_her/media/css/jersey-customisations.css
@@ -17,10 +17,8 @@
 }
 
 @media print {
-    /* note: '.toggle-container' has been removed on dev/7.6.x */
     .mapboxgl-ctrl-geocoder,
-    .workbench-card-sidebar,
-    .report-print-date  > .toggle-container {
+    .workbench-card-sidebar {
         display: none;
     }
 
@@ -32,14 +30,4 @@
         display: block;
     }
 
-    /* Fix multi-page printing bug (fixed on dev/7.6.x) */
-
-    #container {
-        height: auto !important;
-    }
-
-    .resource-component-abstract {
-        height: auto !important;
-        overflow: visible !important;
-    }
 }

--- a/jersey_her/media/css/jersey-customisations.css
+++ b/jersey_her/media/css/jersey-customisations.css
@@ -33,6 +33,11 @@
     }
 
     /* Fix multi-page printing bug (fixed on dev/7.6.x) */
+
+    #container {
+        height: auto !important;
+    }
+
     .resource-component-abstract {
         height: auto !important;
         overflow: visible !important;


### PR DESCRIPTION
This fixes a bug where the map header doesn't show properly in reports (see comment in  https://github.com/archesproject/arches/issues/7839

It also removes some interactive elements of the map that aren't needed when printing the report. 

The `@media print` statement in `arches.scss` still seems applies, unless specifically overruled, so only minimal additions to `jersey-customisations.css` are needed. 

Note that at first this branch originally also added an additional fix to report printing (https://github.com/archesproject/arches/pull/12086/files), but these changes were added to core in stable/7.6.11, so were no longer needed. 

This change should probably also be fed back into core Arches. 

