### PR TITLE
Update to 7.6.24

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,10 +7,10 @@
             "name": "jersey_her",
             "license": "AGPL-3.0-only",
             "dependencies": {
-                "arches": "archesproject/arches#stable/7.6.17"
+                "arches": "archesproject/arches#stable/7.6.24"
             },
             "devDependencies": {
-                "arches-dev-dependencies": "archesproject/arches-dev-dependencies#stable/7.6.17"
+                "arches-dev-dependencies": "archesproject/arches-dev-dependencies#stable/7.6.24"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -3533,19 +3533,6 @@
                 "url": "https://github.com/sindresorhus/is?sponsor=1"
             }
         },
-        "node_modules/@sindresorhus/merge-streams": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
-            "integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/@szmarczak/http-timer": {
             "version": "4.0.6",
             "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
@@ -6740,7 +6727,6 @@
                 "@vue/test-utils": "^2.4.5",
                 "babel-loader": "^9.1.3",
                 "clean-webpack-plugin": "^4.0.0",
-                "copy-webpack-plugin": "^12.0.2",
                 "cross-env": "^7.0.3",
                 "cross-fetch": "^4.0.0",
                 "css-loader": "^7.1.1",
@@ -7905,31 +7891,6 @@
             "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/copy-webpack-plugin": {
-            "version": "12.0.2",
-            "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-12.0.2.tgz",
-            "integrity": "sha512-SNwdBeHyII+rWvee/bTnAYyO8vfVdcSTud4EIb6jcZ8inLeWucJE0DnxXQBjlQ5zlteuuvooGQy3LIyGxhvlOA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "fast-glob": "^3.3.2",
-                "glob-parent": "^6.0.1",
-                "globby": "^14.0.0",
-                "normalize-path": "^3.0.0",
-                "schema-utils": "^4.2.0",
-                "serialize-javascript": "^6.0.2"
-            },
-            "engines": {
-                "node": ">= 18.12.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/webpack"
-            },
-            "peerDependencies": {
-                "webpack": "^5.1.0"
-            }
         },
         "node_modules/core-js": {
             "version": "3.46.0",
@@ -10988,37 +10949,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/globby": {
-            "version": "14.1.0",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-14.1.0.tgz",
-            "integrity": "sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@sindresorhus/merge-streams": "^2.1.0",
-                "fast-glob": "^3.3.3",
-                "ignore": "^7.0.3",
-                "path-type": "^6.0.0",
-                "slash": "^5.1.0",
-                "unicorn-magic": "^0.3.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/globby/node_modules/ignore": {
-            "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-            "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 4"
             }
         },
         "node_modules/globjoin": {
@@ -14354,19 +14284,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/path-type": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/path-type/-/path-type-6.0.0.tgz",
-            "integrity": "sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/pathe": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
@@ -16459,19 +16376,6 @@
             "integrity": "sha512-hNj1/oZ7ygsfmPZ7ZfN5MUBRoGg1gtpnImuJBgLO0ljQ67DtJuiQaiYdS4lUA6s0KCwnPhGivtC/WRwIZLkHyg==",
             "license": "MIT"
         },
-        "node_modules/slash": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
-            "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=14.16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/slice-ansi": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
@@ -18211,19 +18115,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=4"
-            }
-        },
-        "node_modules/unicorn-magic": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
-            "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/unist-util-stringify-position": {

--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
         "vitest": "vitest --run --coverage"
     },
     "dependencies": {
-        "arches": "archesproject/arches#stable/7.6.20"
+        "arches": "archesproject/arches#stable/7.6.24"
     },
     "devDependencies": {
-        "arches-dev-dependencies": "archesproject/arches-dev-dependencies#stable/7.6.20"
+        "arches-dev-dependencies": "archesproject/arches-dev-dependencies#stable/7.6.24"
     },
     "nodeModulesPaths": {
     },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,8 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "arches==7.6.20",
+    "arches>=7.6.24,<7.7.0",
+    "redis",
 ]
 version = "0.0.1"
 


### PR DESCRIPTION
Update pyproject.toml, package-lock.json, and package.json with the new patch version.

`copy-webpack-plugin` is also removed from package-lock, as this was removed in 7.6.23. 

